### PR TITLE
Fix typo in -f argument to /usr/lib/dovecot/deliver

### DIFF
--- a/recipes/postfix.rb
+++ b/recipes/postfix.rb
@@ -88,10 +88,10 @@ node.default['postfix']['master']['inet:smtps']['args'] =
 
 # dovecot   unix  -       n       n       -       -       pipe
 #   flags=DRhu user=vmail:vmail argv=/usr/bin/spamc -e /usr/lib/dovecot/deliver
-#     -f {sender} -d ${recipient}
+#     -f ${sender} -d ${recipient}
 dovecot_argv = [
   "#{node['dovecot']['lib_path']}/deliver",
-  '-f {sender}',
+  '-f ${sender}',
   '-d ${recipient}'
 ]
 if node['postfix-dovecot']['spamc']['enabled']


### PR DESCRIPTION
This typo caused an invalid sender to be used when forwarding mails via sieve filter, for example:
```
Sep  1 11:32:01 xxx postfix/qmgr[485]: XXXXXXXXX: from=<{sender}@mail.xxx.xxx>, size=10829, nrcpt=1 (queue active)
```