### PR TITLE
Make postfixadmin installation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ Attributes
 | `node['postfix-dovecot']['vmail']['gid']`         | `node['postfix-dovecot']['vmail']['uid']` | Virtual mail system group id.
 | `node['postfix-dovecot']['vmail']['home']`        | `'/var/vmail'`         | Virtual mail user home path.
 
+## Postfixadmin Attributes
+
+You can use `node['postfix-dovecot']['postfixadmin']['enabled']` to disable the installation of Postfixadmin.
+
+| Attribute                                    | Default        | Description                       |
+|:---------------------------------------------|:---------------|:----------------------------------|
+| `node['postfix-dovecot']['postfixadmin']['enabled']`  | `true`        | Whether to enable [Postfixadmin](https://github.com/zuazo/postfixadmin-cookbook).
+
 ## Amazon SES Attributes
 
 You can use `node['postfix-dovecot']['ses']['enabled']` to enable SES for sending emails.

--- a/attributes/postfixadmin.rb
+++ b/attributes/postfixadmin.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 #
 # Cookbook Name:: postfix-dovecot
-# Recipe:: postfixadmin
+# Attributes:: postfixadmin
 # Author:: Xabier de Zuazo (<xabier@zuazo.org>)
 # Copyright:: Copyright (c) 2013 Onddo Labs, SL.
 # License:: Apache License, Version 2.0
@@ -19,14 +19,4 @@
 # limitations under the License.
 #
 
-if node['postfix-dovecot']['postfixadmin']['enabled']
-    node.default['postfixadmin']['server_name'] =
-      node['postfix-dovecot']['hostname']
-    node.default['postfixadmin']['common_name'] =
-      node['postfix-dovecot']['hostname']
-    node.default['postfixadmin']['database']['type'] =
-      node['postfix-dovecot']['database']['type']
-
-    include_recipe 'postfixadmin'
-    include_recipe 'postfixadmin::map_files'
-end
+default['postfix-dovecot']['postfixadmin']['enabled'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -258,4 +258,3 @@ attribute 'postfix-dovecot/postfixadmin/enabled',
           choice: %w(true false),
           required: 'recommended',
           default: 'true'
-

--- a/metadata.rb
+++ b/metadata.rb
@@ -250,3 +250,12 @@ attribute 'postfix-dovecot/srpm/rpm_regexp',
           type: 'hash',
           required: 'optional',
           calculated: true
+
+attribute 'postfix-dovecot/postfixadmin/enabled',
+          display_name: 'postfixadmin enabled',
+          description: 'Whether to enable Postfixadmin.',
+          type: 'string',
+          choice: %w(true false),
+          required: 'recommended',
+          default: 'true'
+

--- a/recipes/postfixadmin.rb
+++ b/recipes/postfixadmin.rb
@@ -20,13 +20,13 @@
 #
 
 if node['postfix-dovecot']['postfixadmin']['enabled']
-    node.default['postfixadmin']['server_name'] =
-      node['postfix-dovecot']['hostname']
-    node.default['postfixadmin']['common_name'] =
-      node['postfix-dovecot']['hostname']
-    node.default['postfixadmin']['database']['type'] =
-      node['postfix-dovecot']['database']['type']
+  node.default['postfixadmin']['server_name'] =
+    node['postfix-dovecot']['hostname']
+  node.default['postfixadmin']['common_name'] =
+    node['postfix-dovecot']['hostname']
+  node.default['postfixadmin']['database']['type'] =
+    node['postfix-dovecot']['database']['type']
 
-    include_recipe 'postfixadmin'
-    include_recipe 'postfixadmin::map_files'
+  include_recipe 'postfixadmin'
+  include_recipe 'postfixadmin::map_files'
 end


### PR DESCRIPTION
### Description

This change makes the installation of postfixadmin optional by setting the attribute `node['postfix-dovecot']['postfixadmin']['enabled']` to `false`.

As-is, my change does not include any additional test coverage.  I don't have much experience in this area, but if coverage is required and you could point me to where I should include the test, I can take a swing at it.

### Issues Resolved

zuazo/postfix-dovecot-cookbook/issues/8

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README and metadata if applicable.

See [CONTRIBUTING.md](https://github.com/zuazo/postfix-dovecot-cookbook/blob/master/CONTRIBUTING.md).
